### PR TITLE
del ganhar com gu #106

### DIFF
--- a/verbs/verbs-g.dict
+++ b/verbs/verbs-g.dict
@@ -7865,16 +7865,6 @@ ganhabilizásseis	ganhabilizar+V+SBJP+2+PL
 ganhabilizássemos	ganhabilizar+V+SBJP+1+PL
 ganhabilizávamos	ganhabilizar+V+IMPF+1+PL
 ganhabilizáveis	ganhabilizar+V+IMPF+2+PL
-gangue	ganhar+V+SBJR+3+SG
-gangue	ganhar+V+SBJR+1+SG
-gangue	ganhar+V+IMP+3+SG
-ganguei	ganhar+V+PRF+1+SG
-gangueis	ganhar+V+SBJR+2+PL
-ganguem	ganhar+V+SBJR+3+PL
-ganguem	ganhar+V+IMP+3+PL
-ganguemos	ganhar+V+SBJR+1+PL
-ganguemos	ganhar+V+IMP+1+PL
-gangues	ganhar+V+SBJR+2+SG
 ganha	ganhar+V+PTPST+F+SG
 ganha	ganhar+V+PRS+3+SG
 ganha	ganhar+V+IMP+2+SG


### PR DESCRIPTION
Como dito em #106, as flexões do verbo _ganhar_ em que houve troca do h dígrafo nh por alguma outra letra foram eliminadas.