### PR TITLE
Issue 120

### DIFF
--- a/nouns/nouns-c.dict
+++ b/nouns/nouns-c.dict
@@ -25697,6 +25697,7 @@ chassi	chassi+N+M+SG
 chassis	chassi+N+M+PL
 chassizinho	chassi+N+DIM+M+SG
 chassizinhos	chassi+N+DIM+M+PL
+chassis	chassis+N+M
 chata	chata+N+F+SG
 chatas	chata+N+F+PL
 chatazinha	chata+N+DIM+F+SG


### PR DESCRIPTION
As formas de _aspergir_ que estavam faltando (variações do particípio passado) foram incluídas assim como a entrada unificada das classificações de _chassis_ com lema _chassis_.